### PR TITLE
Ignore any chages in EBS resources

### DIFF
--- a/src/parser/handler.py
+++ b/src/parser/handler.py
@@ -19,9 +19,10 @@ def lambda_handler(event, context):
     else:
         diff = json.loads(event['invokingEvent'])
         if diff['configurationItemDiff']:
-            for k,v in diff['configurationItemDiff']['changedProperties'].items():
+            for k, v in diff['configurationItemDiff']['changedProperties'].items():
                 if 'BlockDeviceMappings' in k:
-                    _logger.info(f'The EBS attaching was marked as spam. Skip execution.')
+                    _logger.info(
+                        f'The EBS attaching was marked as spam. Skipped.')
                 elif 'Relationships' in k:
                     try:
                         if v['previousValue']['resourceType'] == "AWS::EC2::Volume":
@@ -36,7 +37,8 @@ def lambda_handler(event, context):
                 else:
                     trigger_lambda = True
             if trigger_lambda:
-                _logger.info(f'Triggering {os.environ.get("INVENTORY_FUNCTION_NAME")} lambda')
+                _logger.info(
+                    f'Triggering {os.environ.get("INVENTORY_FUNCTION_NAME")} lambda')
                 response = client.invoke(
                     FunctionName=os.environ.get('INVENTORY_FUNCTION_NAME'),
                     InvocationType='Event',
@@ -45,7 +47,7 @@ def lambda_handler(event, context):
                 )
 
                 status_code = response['StatusCode']
-                
+
         else:
             _logger.info('No "configurationItemDiff". Skip execution.')
 

--- a/src/parser/handler.py
+++ b/src/parser/handler.py
@@ -21,7 +21,18 @@ def lambda_handler(event, context):
         if diff['configurationItemDiff']:
             for k,v in diff['configurationItemDiff']['changedProperties'].items():
                 if 'BlockDeviceMappings' in k:
-                    _logger.info(f'The EBS update was marked as spam. Skip execution.')
+                    _logger.info(f'The EBS attaching was marked as spam. Skip execution.')
+                elif 'Relationships' in k:
+                    try:
+                        if v['previousValue']['resourceType'] == "AWS::EC2::Volume":
+                            _logger.info(f'The EBS updating was marked as spam. Skip execution.')
+                    except TypeError:
+                        pass
+                    try:
+                        if v['updatedValue']['resourceType'] == "AWS::EC2::Volume":
+                            _logger.info(f'The EBS updating was marked as spam. Skip execution.')
+                    except TypeError:
+                        pass
                 else:
                     trigger_lambda = True
             if trigger_lambda:

--- a/src/parser/handler.py
+++ b/src/parser/handler.py
@@ -100,8 +100,8 @@ def lambda_handler(event, context):
                 elif 'Relationships' in k:
                     '''
                     Skip resources defined in `ignore_aws_resource_list` attribute
-                    of `skip_changes` funtion.
-                    Explanation of using 'not' operator:
+                    of `skip_changes` function.
+                    Explanation for using 'not' operator:
                         The `skip_changes` function returns True if resource
                         should be skipped. Thats means lambda should NOT be triggered.
                     '''

--- a/src/parser/handler.py
+++ b/src/parser/handler.py
@@ -91,12 +91,9 @@ def lambda_handler(event, context):
             '''
             for k, v in diff['configurationItemDiff']['changedProperties'].items():
                 if 'BlockDeviceMappings' in k:
-                    '''
-                    Skip the input event with a simple attaching/detaching
-                    EBS volume action.
-                    '''
-                    _logger.info(
-                        f'The EBS attaching was marked as spam. Skipped.')
+                    _logger.info('''
+                        Skip the attaching/detaching EBS volume action.
+                    ''')
                 elif 'Relationships' in k:
                     '''
                     Skip resources defined in `ignore_aws_resource_list` attribute

--- a/src/parser/handler.py
+++ b/src/parser/handler.py
@@ -106,6 +106,11 @@ def lambda_handler(event, context):
                         should be skipped. Thats means lambda should NOT be triggered.
                     '''
                     trigger_lambda = not skip_changes(v, ["AWS::EC2::Volume"])
+                elif 'Configuration.LatestRestorableTime' in k:
+                    _logger.info('''
+                        Skip the regular update of "LatestRestorableTime" parameter of
+                        RDS instance.
+                    ''')
                 else:
                     trigger_lambda = True
             if trigger_lambda:


### PR DESCRIPTION
# Desription

The PR was created to ignore any updates in EBS volume in order to skip report triggering via email because it produces a lot of unnecessary messages.

# Before an update

The input event that was TRIGGERING a report 

```json
"Relationships.0": {
        "previousValue": {
          "resourceId": "vol-0cf23d22b71819fa3",
          "resourceName": null,
          "resourceType": "AWS::EC2::Volume",
          "name": "Is attached to Volume"
        },
        "updatedValue": null,
        "changeType": "DELETE"
      },
```

# After the update

```log
The EBS updating was marked as spam. Skip execution.
```